### PR TITLE
Fix typo in Singleton pattern section (factory → singleton)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ factory class determines which object is created.
 - It makes your code more readable and understandable by abstracting the object creation process.
 - It makes the software development process more efficient.
 
-<h5 align="left"> Disadvantages of the factory design pattern:</h5>
+<h5 align="left"> Disadvantages of the singleton design pattern:</h5>
 
 - It may be difficult to use in complex applications.
 - It may cause you to write more code.


### PR DESCRIPTION
## Fix: Typo in Singleton Pattern Section 
- closed #2

### Context
This pull request fixes a small typo found in the **Singleton** pattern section of the README file.

The section is clearly discussing the Singleton pattern, but the header mistakenly refers to the "factory design pattern".

### Change Summary
- **Before:** `Disadvantages of the factory design pattern`
- **After:** `Disadvantages of the singleton design pattern`

This correction helps maintain clarity and consistency throughout the documentation.

---

Thank you for maintaining such a helpful and well-structured repository🚀