### PR TITLE
Fix correct Singleton section and revert Factory section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ factory class determines which object is created.
 - It makes your code more readable and understandable by abstracting the object creation process.
 - It makes the software development process more efficient.
 
-<h5 align="left"> Disadvantages of the singleton design pattern:</h5>
+<h5 align="left"> Disadvantages of the factory design pattern:</h5>
 
 - It may be difficult to use in complex applications.
 - It may cause you to write more code.
@@ -333,7 +333,7 @@ fun ThemeSwitchingApp() {
 - Makes your code more readable and understandable.
 - It makes the software development process more efficient.
 
-<h5 align="left"> Disadvantages of the factory design pattern</h5>
+<h5 align="left"> Disadvantages of the Singleton design pattern</h5>
 
 - It may be difficult to use in complex applications.
 - It may cause you to write more code.


### PR DESCRIPTION
## Summary
- closed #4

This PR corrects a small typo in the README related to section headings:

- Reverts an unintended change made in the **Factory Method** section (`line 65`)
- Corrects the actual typo in the **Singleton** section (`line 336`)

---

## Context

In my previous PR, I intended to fix the following typo:

```html
<h5 align="left">Disadvantages of the factory design pattern</h5>
```

…which incorrectly appears in the Singleton section (line 336).
However, I mistakenly applied the change to line 65 in the Factory Method section, which was already correct.

## Changes Made
- Restored line 65 to:

  ```html
  <h5 align="left">Disadvantages of the factory design pattern</h5>
  ```

- Updated line 336 to:
  ```html
  <h5 align="left">Disadvantages of the singleton design pattern</h5>
  ```